### PR TITLE
Updating the `realizedIn' relation to reflect "Only" rather than "Some"

### DIFF
--- a/fmea-iso.ttl
+++ b/fmea-iso.ttl
@@ -59,7 +59,7 @@ _:genid2 a rdf:List ;
 
 _:genid3 a owl:Restriction ;
 	owl:onProperty lis:realizedIn ;
-	owl:someValuesFrom fso:Process .
+	owl:allValuesFrom fso:Process .
 
 _:genid2 rdf:rest rdf:nil .
 
@@ -192,7 +192,7 @@ _:genid17 a owl:Restriction ;
 
 _:genid18 a owl:Restriction ;
 	owl:onProperty lis:realizedIn ;
-	owl:someValuesFrom owl:Thing .
+	owl:allValuesFrom owl:Thing .
 
 _:genid17 rdfs:subClassOf :ObjectInFaultState .
 # 


### PR DESCRIPTION
Comments from Johan's email below:

"The realizedIn arrow should be "(only)" -- any component has a function, but it's not a given that the function will every be realized (as Barry often points out, and as in, the component rusts in storage before it's ever installed).
 
To check this it makes sense to look at the ontology again. Looking at github.com/uwasystemhealth/modular_ontologies/blob/master/fmea-iso.ttl, the restriction with "some" should rather be "only". I'll admit that this should be improved in the upper ontology, but at least the figure needs to be updated. (The range of realizedIn is Activity -- hence it's correct to write "(only)" for the realizedIn arrow; the inference to "object in fault state" is not affected (fortunately :) )."